### PR TITLE
add 'strict mode' functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Bitfit 1.1.0
 Usage: bitfit.py [OPTIONS] [STARTING DIRECTORY]
      - With no arguments, recursively calculate hashes for all files
 -v   - Search for a VERSION verification file and validate hashes
+-s   - Strict mode (with -v): Don't ignore validation of filesystem detritus
+       (Strict mode is always enabled for hash file creation.)
 -l   - Reduce memory consumption for hashing on low memory systems
 -t   - Print timing and media speed information on STDERR
 
@@ -61,6 +63,8 @@ $ bitfit -v /Volumes/SEC617
 +  added-file
 Validation failed.
 ```
+
+In Verification Mode, testing is done in non-strict mode, in which common filesystem detritus files are ignored.  These files are created upon inserting the USB and mounting the filesystem in read-write mode.  By running in non-strict mode, a verification run can still be successful even if such detritus files are present.  Strict mode can be enforced during a verification run with the `-s` flag.
 
 ## Timing and media speed calculation
 

--- a/bitfit.py
+++ b/bitfit.py
@@ -101,15 +101,16 @@ def validate_hashes(verfile, startdir, hashes, strict):
             break
         if line[0].startswith("#") or line[0].startswith("VERSION-"):
             continue
-        if not opt_strict and line[0].startswith(ignore_list):
-            continue
         verhashes.append((line[0], line[1], line[2]))
     verhashes.sort()
 
     missingdiff = list(set(verhashes) - set(hashes))
     if missingdiff:
-        verified=False
         for diff in missingdiff:
+            if not strict and diff[0].startswith(ignore_list) and os.path.isfile(os.path.join(startdir,diff[0])):
+                continue
+
+            verified=False
             # Check if the file exists - if it does, it's a change to the file
             if os.path.isfile(os.path.join(startdir,diff[0])):
                 # only report this entry as a change once
@@ -120,8 +121,11 @@ def validate_hashes(verfile, startdir, hashes, strict):
 
     addeddiff = list(set(hashes) - set(verhashes))
     if addeddiff:
-        verified=False
         for diff in addeddiff:
+            if not strict and diff[0].startswith(ignore_list):
+                continue
+
+            verified=False
             if diff[0] not in observedfiles:
                 print "+  %s"%diff[0]
 


### PR DESCRIPTION
This PR provides more robust handling of filesystem detritus artifacts (i.e. ignoring them).  This has become a major problem for the USB validation process, in which a validation USB is erroneously mounted R/W before validation.  The detritus (`.Spotlight*`, `.DS_Store`, `System Volume Information/`, etc.) is created immediately upon mounting the filesystem, causing a validation failure.

The attached PR behaves as such:
- If in normal hashset creation mode, there is no change to the tool's behavior - all files will be reflected in the `VERSION-*` file.
- If run in verification mode, detritus files on disk but not in the `VERSION-*` file will be ignored.  Detritus files that are in the `VERSION-*` file will not be ignored.  (The latter case is not expected to be common.)